### PR TITLE
Operational Emissions - edit to re-architecting software sentence

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -172,7 +172,7 @@ Green Software broadly addresses emissions in these categories.
 
 To calculate the operational emissions associate with software, multiply the electricity consumption of the hardware the software is running on by the regional, granular marginal emissions rate. Because this standard uses a consequential approach, marginal emissions rates should be used for electricity consumption. The marginal emissions rate reflects the change in emissions assoicated with a change in demand. 
 
-Carbon aware software will optimize the timing and location of operation to minimize emissions associated with operation. This could consist of moving computation to regions with cleaner grid emissions or delaying jobs to cleaner periods (or a combination of both). Energy efficient software will also run on hardware that requires less energy to operate or the solution can be re-architected to take advantage of different configurations that scale better in terms of efficiency. All combined, these effects should be reflected in the total operational emissions. 
+Carbon aware software will optimize the timing and location of operation to minimize emissions associated with operation. This could consist of moving computation to regions with cleaner grid emissions or delaying jobs to cleaner periods (or a combination of both). Energy efficient software will also run on hardware that requires less energy to operate or the software can be re-architected to require less energy to execute. All combined, these effects should be reflected in the total operational emissions. 
 
 
 #### Embodied Emissions


### PR DESCRIPTION
This commit edits the operational Emissions characteristic so that re-architecting your software to be greener isn't necessary about scaling up or down, and just focused on being more energy efficient. This covers a broader set of use cases to improve the specification, I hope :) 