### PR TITLE
Added ref to principles.green and moved to markdown table

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -41,25 +41,10 @@ Add/Remove reference rows as needed - DELETE This Row
 
 ### Informative References
 
-```
-Check the version of the Dictionary you are using and update the reference below. Delete the [GSFDICT] entry if the Dictionary is not used. In general, use the latest
-available version unless seeking alignment with an existing set of specifications.
-
-DELETE THIS COMMENT
-```
-<table>
-  <caption>Informative References </caption>
-  <tbody>
-    <tr>
-      <td><strong>[GSFDICT]</strong></td>
-      <td>"Dictionary for GSF Specifications", Version x.y, Green Software Foundation™, GSF-ORG-Dictionary-Vx_y, URL:http://greensoftware.foundation/</td>
-    </tr>
-  </tbody>
-</table>
-
-```
-Add/Remove references as needed - DELETE This Row
-```
+|||
+| ----------- | ----------- |
+| **[GSFDICT]** | https://github.com/Green-Software-Foundation/Dictionary |
+| **Principles of Green Software Engineering** | https://principles.green |
 
 ## Terminology and Conventions
 ### Conventions


### PR DESCRIPTION
Included an informative reference to https://principles.green (I forgot what issue it was discussed in!). 

Also turned it into a markdown table from an HTML table since the link gets automatically converted into a clickable link with markdown.