### PR TITLE
added guidance on reporting the SCI value

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -202,6 +202,10 @@ To achieve impact at scale, the SCI needs to encourage adoption through ease of 
 - Calculation of the SCI MUST be possible without incurring any cost, for instance, for data or services or tooling.
 - Where possible, teams SHOULD consider investing more time or money in calculating their SCI number to increase its accuracy.
 
+### Reporting the SCI value
+
+You MUST report the `CI` value and you SHOULD report the `C` value but if you are unable to report the `C` value, you MUST provide a reason for why you are unable to do so.
+
 ## Exclusions
 
 Because this standard lays out a consequential methodology for calculating the emissions associated with a piece of software, the following must not be included in the calculation: 


### PR DESCRIPTION
addresses exposing `C` and `CI` as per issue #38 that will close it out. 