### PR TITLE
Adding building, training, redundancy and failover to the boundary list

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -144,9 +144,9 @@ The calculation of software carbon intensity MUST include all supporting infrast
 - idle machines
 - logging
 - scanning
-- building
+- build and deploy pipelines
 - testing
-- training
+- training ML models
 - operations
 - backup
 - resources to support redundancy

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -149,7 +149,8 @@ The calculation of software carbon intensity MUST include all supporting infrast
 - training
 - operations
 - backup
-- redundancy and failover
+- resources to support redundancy
+- resources to support failover
 
 The entity calculating software carbon intensity MUST report what is included within this boundary.  
 

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -144,11 +144,12 @@ The calculation of software carbon intensity MUST include all supporting infrast
 - idle machines
 - logging
 - scanning
-= building
+- building
 - testing
+- training
 - operations
 - backup
-- failover
+- redundancy and failover
 
 The entity calculating software carbon intensity MUST report what is included within this boundary.  
 

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -144,9 +144,12 @@ The calculation of software carbon intensity MUST include all supporting infrast
 - idle machines
 - logging
 - scanning
+= building
 - testing
 - operations
 - backup
+- failover
+
 The entity calculating software carbon intensity MUST report what is included within this boundary.  
 
 Electricity has a carbon intensity depending on where and when it is consumed. An intensity is a rate. It has a numerator and a denominator. A rate provides you with helpful information when considering the growth of a software product and allows for the computation of a marginal rate.


### PR DESCRIPTION
Adding building, training, redundancy and failover to the boundary list, details in Issue #78 

3 bullet points added - Building, Training, Redundancy and failover
Formatting - the paragraph following the boundary list is now separated so it doesn't append to the last bullet point.