### PR TITLE
[Consistency Review] Removed repeated verbiage in Quantification method section

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -188,6 +188,8 @@ A suggested list of functional units includes:
 
 ## Quantification Method
 
+The third step in generating your SCI score is deciding the approach to take when quantifying the carbon emissions for *each component* in your software boundary.
+
 The goal of the SCI is to **quantify** how much `C` (carbon) is emitted per **one unit** of `R`. 
 
 There are two main approaches to quantifying carbon emissions (`C`), [measurement](#measurement) via real-world data or [calculation](#calculation) via models.

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -194,8 +194,6 @@ There are two main approaches to quantifying carbon emissions (`C`), [measuremen
 
 Each component in your software boundary MAY use either measurement or calculation to quantify the carbon emissions.
 
-The third step in generating your SCI score is deciding the approach to take when quantifying the carbon emissions for *each component* in your software boundary.
-
 We strongly advise speaking to your suppliers (be they hardware, hosting, or other) and requesting the data you need in the resolution you require for quantifying your SCI score.
 
 ### Measurement


### PR DESCRIPTION
Removed the line from Quantification method that was redundant, Also it spoke about a "third" step when the first and second steps are not discussed in this section.