### PR TITLE
Update Software_Carbon_Intensity_Specification.md

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -120,7 +120,7 @@ To calculate the share of `M` for a software application, we use:
 
 Where:
 
-- `TE` = Total Embodied Emissions, the sum of LCA emissions for all hardware components.
+- `TE` = Total Embodied Emissions, the sum of Life Cycle Assessment (LCA) emissions for all hardware components.
 - `TR` = Time Reserved, the length of time the hardware is reserved for use by the software.
 - `EL` = Expected Lifespan, the anticipated time that the equipment will be installed.
 - `RR` = Resources Reserved, the number of resources reserved for use by the software.
@@ -132,7 +132,7 @@ We can further refine the equation to
 
 Where:
 
-- `TE` = Total Embodied Emissions, the sum of Life Cycle Assessment (LCA) emissions for all hardware components.
+- `TE` = Total Embodied Emissions, the sum of LCA emissions for all hardware components.
 - `TS = TR/EL` = Time-share, the share of the total life span of the hardware reserved for use by the software.
 - `RS = RR/TR` = Resource-share, the share of the total available resources of the hardware reserved for use by the software.
 
@@ -222,7 +222,7 @@ As the SCI specification matures and develops, these core characteristics MUST r
 ### The SCI takes a systems-impact view
 
 - The purpose of the SCI is to encourage actions that reduce carbon emissions of software in a way that create reductions at a system-wide level rather than just at a local level. Local level optimizations MAY lead to micro-improvements but MAY have negative downstream impacts at a macro-level that negate the impact of those actions.
-- Such a systems view MUST be adopted by articulating the [boundaries](#boundaries) of the software and its associated infrastructure, keeping in mind the [exclusions](#exclusions) mentioned in this specification.
+- Such a systems view MUST be adopted by articulating the [boundaries](#software-boundary) of the software and its associated infrastructure, keeping in mind the [exclusions](#exclusions) mentioned in this specification.
 
 ### The SCI is easy to implement
 

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -39,7 +39,7 @@ All actions that can reduce the carbon emissions of a piece of software fall int
 The steps required to calculate and report an SCI score are:
 
 1. **What**: Decide on the [software boundary](#software-boundary), i.e. the components of a software system to include.
-1. **Scale**: The SCI is a rate, carbon emissions per one [functional unit](#functional-unit). The next step is to pick the functional unit which best describes how the application scales.
+1. **Scale**: The SCI is a rate, carbon emissions per one [functional unit](#functional-unit-r). The next step is to pick the functional unit which best describes how the application scales.
 1. **How**: For each software component listed in the software boundary, decide on the [quantification method](#quantification-method), real-world measurements based on telemetry, or lab-based measurements based on models.
 1. **Quantify**: Calculate a rate, an SCI value, for every software component. The SCI value of the whole application is the sum of the SCI values for every software component in the system.
 1. **Report**. The SCI has standards for reporting that must be met, including a disclosure of the software boundary and the calculation methodology.


### PR DESCRIPTION
1. The software-boundary and functional unit was not linked correctly.
2. Readability - LCA definition was defined later, moved it to the first reference.
