### PR TITLE
Add calculation-period to reporting elements

### DIFF
--- a/Software_Carbon_Intensity/Appendix_A_Further_Information_on_Reporting_Requirements.md
+++ b/Software_Carbon_Intensity/Appendix_A_Further_Information_on_Reporting_Requirements.md
@@ -22,6 +22,8 @@ The following list contains the REQUIRED and OPTIONAL data elements to be report
 | Software or Product Version | metadata/entity-version | MUST | Text | |
 | SCI Specification Version | metadata/sci-version | MUST | Numeric | The version of the SCI specification against which this report is being made. |
 | Date of Calculation | metadata/calculation-date | MUST | Date | Following a format described in [RFC3339], [a subset](https://ijmacd.github.io/rfc3339-iso8601/) of ISO 8601 |
+| Start date of the workload | metadata/workload-start-time | MAY | Timestamp | Following a format described in [RFC3339], [a subset](https://ijmacd.github.io/rfc3339-iso8601/) of ISO 8601 |
+| Processing period for calculation | metadata/calculation-period | MAY | Numeric | Time taken in seconds to complete the process defined by `R`.  |
 | Further information on calculation | metadata/calculation-information | MAY | Text | More information on your calculation methodology can be provided as freetext, or as a URL to an external document or software repository. |
 | Further information on report | metadata/report-information-url | MAY | URL | More information on your calculation methodology MAY be provided, and this MUST be a URL to an external document or software repository.  |
 
@@ -66,6 +68,8 @@ metadata:
   entity-version: '0.1'
   sci-version: 1.0
   calculation-date: '2021-10-20'
+  workload-start-time: '2021-10-20T01:23:45Z'
+  calculation-period: 600
   calculation-information: 'https://github.com/Green-Software-Foundation/software_carbon_intensity'
   report-information-url: 'https://github.com/Green-Software-Foundation/software_carbon_intensity'
 

--- a/Software_Carbon_Intensity/Appendix_A_Further_Information_on_Reporting_Requirements.md
+++ b/Software_Carbon_Intensity/Appendix_A_Further_Information_on_Reporting_Requirements.md
@@ -23,7 +23,7 @@ The following list contains the REQUIRED and OPTIONAL data elements to be report
 | SCI Specification Version | metadata/sci-version | MUST | Numeric | The version of the SCI specification against which this report is being made. |
 | Date of Calculation | metadata/calculation-date | MUST | Date | Following a format described in [RFC3339], [a subset](https://ijmacd.github.io/rfc3339-iso8601/) of ISO 8601 |
 | Start date of the workload | metadata/workload-start-time | MAY | Timestamp | Following a format described in [RFC3339], [a subset](https://ijmacd.github.io/rfc3339-iso8601/) of ISO 8601 |
-| Processing period for calculation | metadata/calculation-period | MAY | Numeric | Time taken in seconds to complete the process defined by `R`.  |
+| Processing period for calculation | metadata/calculation-period | MAY | Numeric | Time taken in milliseconds to complete the process defined by `R`.  |
 | Further information on calculation | metadata/calculation-information | MAY | Text | More information on your calculation methodology can be provided as freetext, or as a URL to an external document or software repository. |
 | Further information on report | metadata/report-information-url | MAY | URL | More information on your calculation methodology MAY be provided, and this MUST be a URL to an external document or software repository.  |
 


### PR DESCRIPTION
We discussed about this change on #123 . This PR is based on [this comment](https://github.com/Green-Software-Foundation/software_carbon_intensity/pull/123#issuecomment-948373028).

Add `workload-start-time` and `calculation-period` to SCI reporting elements as optional fields.
It helps us to understand the impact of start times and processing times of workloads on SCI.

We can analyze, and feedback to run the job more efficiency with this PR. So I hope merge this PR to v1.0.