### PR TITLE
Change Reporting Requirement in Procedure

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -53,7 +53,7 @@ The steps required to calculate and report an SCI score are:
 1. **Scale**: The SCI is a rate; carbon emissions per one [functional unit](#functional-unit-r). The next step is to pick the functional unit which best describes how the application scales.
 1. **Define**: For each software component listed in the software boundary, decide on the [quantification method](#quantification-method); real-world measurements, based on telemetry or lab-based measurements, based on models.
 1. **Quantify**: Calculate a rate (an SCI value) for every software component. The SCI value of the whole application is the sum of the SCI values for every software component in the system.
-1. **Report**. The SCI has standards for reporting that must be met, including a disclosure of the software boundary and the calculation methodology.
+1. **Report**. Disclosure the SCI score, software boundary, and the calculation methodology.
 
 ## Methodology Summary
 


### PR DESCRIPTION
Instead of requiring reporting (which we have not yet developed requirements for) just indicate that reporting should be done.