### PR TITLE
Block quotes - ISO formatting requirements

### DIFF
--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -34,7 +34,9 @@ The SCI encourages calculation using granular real-world data, which is challeng
 
 In situations where there is a lack of access, capability, or rights to the necessary real-world data, the SCI allows for data generated through modeling, using best estimates instead.
 
-## Software Sustainability Actions
+## Software sustainability actions
+
+> Rex: ISO requires all headings to use sentence-case; that is, only the first word can have a leading uppercase letter, unless that and subseqent words are proper nouns spelled with leading and/or embedded uppercase letters. Only this heading has been changed (from "Software Sustainability Actions"), as a sample. Others will need to be downcased as well.
 
 All actions that serve to reduce the carbon emissions of a piece of software fit into one of three categories: 
 

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -1,5 +1,7 @@
 # Software Carbon Intensity (SCI) Specification (v.Alpha)
 
+> Rex: The [ISO House Style](https://www.iso.org/ISO-house-style.html) states, "Use an impersonal tone. Avoid “I”, “we”, “you” and other personal pronouns." This means getting rid of "you" and "your", for example.
+
 ## Scope
 
 This document, the Software Carbon Intensity technical specification, describes a methodology for calculating the rate of carbon emissions for a software system. The purpose of the score is to increase awareness and transparency of an applications sustainability credentials. The score will help software practitioners make better, evidence-based, decisions during system design, development, and deployment, that will ultimately minimize carbon emissions. A reliable, consistent, fair and comparable measure allows targets to be defined during development and progress to be tracked.

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -340,6 +340,8 @@ Kindly consult [GSFDICT] for more definitions used in this document.
 ## Terminology and Conventions
 ### Conventions
 
+> Rex: ISO does *NOT* use RFC2119 conventions! Instead it uses "shall", "shall not", "should", "should not", "may", "can", "cannot", "must". See [7 Verbal forms for expressions of provisions](https://www.iso.org/sites/directives/current/part2/index.xhtml#_idTextAnchor078).
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119].
 
 All sections and appendixes, except "Scope" and "Introduction", are normative unless they are explicitly indicated to be informative.

--- a/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+++ b/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
@@ -59,6 +59,10 @@ The steps required to calculate and report an SCI score are:
 
 ## Methodology Summary
 
+### General
+
+> Rex: ISO requires that if a section contains any subsections, it *CANNOT* contain any text *BEFORE* the first subsection. As such, the following text must belong to a new subsection, which I have called "General". You might want to call it "Introduction". This is the first of 2 samples.
+
 The Software Carbon Intensity (SCI) is a rate; carbon emissions per one unit of `R`. The equation used to calculate the SCI value of a software system is:
 
 `SCI = C per R`
@@ -77,6 +81,11 @@ Where:
 - `M` = Embodied emissions of the hardware needed to operate a software system
 
 ### Operational Emissions  (`O`)
+
+#### General
+
+> Rex: ISO requires that if a section contains any subsections, it *CANNOT* contain any text *BEFORE* the first subsection. As such, the following text must belong to a new subsection, which I have called "General". You might want to call it "Introduction". Note that by using this approach, headings are no longer unique, which makes it a bit more challenging to reference them in markdown (you must qualify them with a prefix from their parent heading). This is the second of 2 samples.
+
 To calculate the operational emissions associate with software, multiply the electricity consumption of the hardware the software is running on by the regional, granular marginal emissions rate. The marginal emissions rate reflects the change in emissions associated with a change in demand.
 
 To calculate the operational emissions `O` for a software application, we use:


### PR DESCRIPTION
This PR shows a sample of some changes needed to comply with ISO formatting and organization requirements.

I have yet to actually read the spec content in detail. When I do, I expect I'll find other editorial issues that will need attention. There will also be some organization changes. For example, terms and definitions will go in a section up front, as will normative references. Informative references will go in a bibliography at the end.